### PR TITLE
Initial Terminology Section and Definitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -133,6 +133,113 @@
 
     </section>
 
+    <section id="terminology">
+      <h2>Terminology</h2>
+      <p>This document uses the following terms with the specific meanings defined here.
+         Where possible these meanings are consistent with common usage.
+         However, note that common usage of some of these terms have 
+         multiple, ambiguous, or inconsistent meanings.
+         The definition here will take precedence.
+         When terms are used with the specific meanings defined here they will
+         be capitalized.
+         When possible reference to existing standards defining these terms is given.
+      </p>
+      <dl>
+<!-- Example, consistent with ReSpec
+        <dt><dfn data-lt="term" class="lint-ignore">Term</dfn></dt>
+        <dd>Defn.</dd>
+-->
+        <dt><dfn class="lint-ignore">Edge<dt>
+        <dd>
+        The periphery of a network.  
+        </dd>
+        <dt><dfn class="lint-ignore">FaaS<dt>
+        <dd>Function as a Service.
+        A service provided by a Computing Resource that can execute a stateless computation.
+        </dd>
+        <dt><dfn class="lint-ignore">Cloud<dt>
+        <dd>
+        A set of managed services that are 
+        designed to be interchangable, scalable, and location-independent.
+        </dd>
+        <dt><dfn class="lint-ignore">Cloud Resources<dt>
+        <dd>
+        A set of managed Computing Resources available in the Cloud.
+        </dd>
+        <dt><dfn class="lint-ignore">Edge Cloud<dt>
+        <dd>
+        A set of Edge Resources managed as an extension of the Cloud.
+        Such resources use similar abstractions and management APIs as a cloud
+        but typically will add mechanisms to manage location and latency,
+        and will typically be deployed in a less centralized, more location and
+        latency-sensitive manner than a typical Cloud.
+        </dd>
+        <dt><dfn class="lint-ignore">Edge Resource<dt>
+        <dd>
+        A Computing Resource located on the Edge, that is, near the periphery of a network.
+        Note: this definition does not
+        necessarily include "endpoints" such as IoT sensors.
+        It refers specifically to computers
+        that can make Computing Resources available to others on the network.  
+        </dd>
+        <dt><dfn class="lint-ignore">Migration<dt>
+        <dd>
+        The ability to move a workload from one Computing Resources to another.
+        See also Live Migration and Application-Directed Migration, which are subclasses.
+        </dd>
+        <dt><dfn class="lint-ignore">Live Migration<dt>
+        <dd>
+        The ability to transparently move a running workload from one Computing Resources to another.
+        This includes transparent migration of state and updates to references, so that the
+        application that invoked the resource does not need to manage the transition and
+        does not need to be made aware of it.  Such migration needs to be implemented with
+        minimum impact on quality of service factors such as latency of responses.
+        See also the more general defintion of Migration.
+        </dd>
+        <dt><dfn class="lint-ignore">Application-Directed Migration<dt>
+        <dd>
+        The ability to move a running workload from one Computing Resources to another under
+        control of an application.  In this version of Migration, the controlling 
+        application or the Workload itself needs to manage the orderly transfer of state
+        from one Computing Resource to another, and may also have to explictly update
+        references, and will have to explictly manage quality of service factors such
+        as latency of response.
+        See also the more general definition of Migration.
+        </dd>
+        <dt><dfn class="lint-ignore">Computing Resource<dt>
+        <dd>
+        Any computer which can be used to execute a Workload, and may
+        include Edge, Cloud, or Client computers.
+        </dd>
+        <dt><dfn class="lint-ignore">Client Computer<dt>
+        <dd>
+        A Computing Resource used directly by an end user, such as a laptop or desktop.
+        Such a Computing Resource may also act as an Edge Resource if it provides
+        Computing Resources to other systems on the network. 
+        </dd>
+        <dt><dfn class="lint-ignore">CDN<dt>
+        <dd>
+        Content Distribution Network. 
+        A specialized network and set of computers targetted 
+        at caching and delivering content with low latency.
+        May also host Edge Resources.
+        </dd>
+        <dt><dfn class="lint-ignore">MEC<dt>
+        <dd>
+        <a href="https://www.etsi.org/technologies/multi-access-edge-computing">Multi-access Edge Computing</a>. 
+        A form of Edge Computing 
+        based on Computing Resources 
+        typically hosted within a cellular network's infrastructure.
+        </dd>
+        <dt><dfn class="lint-ignore">Workload<dt>
+        <dd>
+        A packaged definition of the compute work required to be executed
+        on a Computing Resource.  
+        For example, a workload might be a container image, a script, or WASM.
+        </dd>
+      </dl>
+    </section>
+
     <section>
       <h2>Use Cases</h2>
       <p>


### PR DESCRIPTION
Resolves #3 

Set of initial terminology definitions based on list in #3, but with the addition of a few more obvious ones like "Cloud".  I tried to avoid leaving empty definitions and also made some calls to make things more precise, for example I defined FaaS to be stateless (this may or may not be consistent with how it is used in the use cases, but I think it is helpful to do that).  Also I defined Migration to be a general term with subclasses "Live Migration" and "Application-Driven Migration" which should be used where appropriate.

The only external standard I cite is for MEC, but I only included a hyperlink.  We probably should use actual specref references here (and include more citations).